### PR TITLE
Set target PG folder fixed to stay compatible with PG18 folder change

### DIFF
--- a/pkg/pgupgrade/pgupgradeaction.go
+++ b/pkg/pgupgrade/pgupgradeaction.go
@@ -8,6 +8,8 @@ import (
 )
 
 func createUpgradeJobActionInput(settings PGUpgradeSettings, sourceSubPath, targetSubPath string, pgUser string, extraInitDBArgs string) JobActions {
+	targetDataDir := fmt.Sprintf("/var/lib/postgresql/%s/data", settings.TargetPostgresVersion)
+
 	jobAction := JobActions{
 		Name:           "pg-upgrade",
 		Script:         upgradePrepareScript,
@@ -49,6 +51,7 @@ func createUpgradeJobActionInput(settings PGUpgradeSettings, sourceSubPath, targ
 				newPodEnvVar("PGUSER", pgUser),
 				newPodEnvVar("POSTGRES_USER", pgUser),
 				newPodEnvVar("POSTGRES_INITDB_ARGS", fmt.Sprintf("-U %s %s", pgUser, extraInitDBArgs)),
+				newPodEnvVar("PGDATANEW", targetDataDir),
 			},
 			VolumeMounts: []v1.VolumeMount{
 				{
@@ -59,7 +62,7 @@ func createUpgradeJobActionInput(settings PGUpgradeSettings, sourceSubPath, targ
 				},
 				{
 					Name:      "new",
-					MountPath: fmt.Sprintf("/var/lib/postgresql/%s/data", settings.TargetPostgresVersion),
+					MountPath: targetDataDir,
 					SubPath:   targetSubPath,
 				},
 			},


### PR DESCRIPTION
### Fix PostgreSQL 18 target data directory

PostgreSQL 18 changed the default data directory from:

```text
/var/lib/postgresql/18/data
```

to:

```text
/var/lib/postgresql/18/docker
```

However, kube-pg-upgrade still mounts the target PVC at `/var/lib/postgresql/18/data`. As a result, the upgrade can complete successfully while writing the new cluster to the container’s ephemeral filesystem, leaving the target persistent volume empty.

This change explicitly sets `PGDATANEW` to the target PVC mount path:

```text
/var/lib/postgresql/<target-version>/data
```

This ensures that `initdb` and `pg_upgrade` write the upgraded cluster to persistent storage. The change is backwards compatible because it matches the directory already used by this application and by older tianon upgrade images.